### PR TITLE
feat(main): work with compound suffixes

### DIFF
--- a/src/vert/__main__.py
+++ b/src/vert/__main__.py
@@ -10,7 +10,14 @@ class SupportedType(Enum):
     ZIP = ".zip"
     TARXZ = ".tar.xz"
     TARGZ = ".tar.gz"
-
+    # Other common compound compressed-file suffixes, commented out because not yet supported.
+    # TARBZ2 = ".tar.bz2"
+    # TARZST = ".tar.zst"
+    # TARLZ = ".tar.lz"
+    # TARLZMA = ".tar.lzma"
+    # TARZ = ".tar.Z"
+    # TAR7Z = ".tar.7z"
+    
     @classmethod
     def from_str(cls, type_s: str):
         if type_s == ".zip":
@@ -20,10 +27,11 @@ class SupportedType(Enum):
         elif type_s == ".tar.gz":
             return cls.TARGZ
 
-
 def _joined_suffix(path: pathlib.Path) -> str:
-    return "".join(path.suffixes[-2:])
-
+    suffix = "".join(path.suffixes[-2:])
+    if suffix in SupportedType._value2member_map_:
+        return suffix
+    return path.suffix
 
 def _check_suffix(path: pathlib.Path, suffix: str | list[str] | tuple[str]):
     suffixes = _joined_suffix(path)
@@ -185,7 +193,11 @@ def extract_archive(file):
                 file,
                 cwd if _tar_is_nested(tar) else cwd / _name_without_suffix(file.name),
             )
-    log.info(f"Finished extracting '%s'", file.relative_to(cwd))
+    try:
+        relative_file = file.relative_to(cwd)
+    except ValueError:
+        relative_file = file
+    log.info(f"Finished extracting '%s'", relative_file)
 
 
 def cmd_list_contents(args):


### PR DESCRIPTION
Per discussion in [issue #1](https://github.com/eeriemyxi/vert/issues/1), this works with compound suffixes (e.g., `.tar.gz`, `.tar.xz`).

Also, my tests involved running a version of `vert` that wasn't in my $PATH, so I was extracting a file in a completely different path than `vert` was in, and got this error:
```
log.info(f"Finished extracting '%s'", file.relative_to(cwd))
^^^^^^^^^^^^^^^^^^^^^
File "/home/john/.pyenv/versions/3.12.2/lib/python3.12/pathlib.py", line 682, in relative_to
raise ValueError(f"{str(self)!r} is not in the subpath of {str(other)!r}")
ValueError: '/home/john/Downloads/arduino-ide_2.3.4_Linux_64bit.zip' is not in the subpath of '/home/john/git/vert'
```
...on [this line](https://github.com/eeriemyxi/vert/blob/c94d017a59e9c61ea8d82e0d3a8258c5a2acdfb7/src/vert/__main__.py#L188):
```python
    log.info(f"Finished extracting '%s'", file.relative_to(cwd))
```
...so I changed it to:
```python
    try:
        relative_file = file.relative_to(cwd)
    except ValueError:
        relative_file = file
    log.info(f"Finished extracting '%s'", relative_file)
```

Penultimately, I tested this in python 3.12.2 (not 3.13.0).

Finally, a reminder: I'm not a coder. This is basically vibe-coded. I recommend you review it better than I'm able to, before accepting it.